### PR TITLE
RDKEMW-1799: rdkvfwupdater crashed in 64 bit

### DIFF
--- a/dwnlutils/urlHelper.c
+++ b/dwnlutils/urlHelper.c
@@ -827,7 +827,7 @@ CURLcode SetPostFields( CURL *curl, char *pPostFields )
 
     if( curl != NULL && pPostFields != NULL )
     {
-        ret_code = curl_easy_setopt( curl, CURLOPT_POSTFIELDSIZE, -1 );
+        ret_code = curl_easy_setopt( curl, CURLOPT_POSTFIELDSIZE, (long)strlen(pPostFields) );
         if( ret_code == CURLE_OK )
         {
             ret_code = curl_easy_setopt( curl, CURLOPT_POSTFIELDS, pPostFields );


### PR DESCRIPTION
Reason for change: * crashed observed during setting curl option for
		     postfield data in 64bit.
Test Procedure: Build should pass with this change and all L1 success
                xconf download should success without any crash
Risks: Low
Priority: P1