### PR TITLE
RDK-58818 : Add api to support url percentage encoding

### DIFF
--- a/dwnlutils/urlHelper.c
+++ b/dwnlutils/urlHelper.c
@@ -1008,6 +1008,42 @@ size_t writeFunction(void *contents, size_t size, size_t nmemb, void *userp)
     return size * nmemb;
 }
 
+/*
+ * urlEncodeString(): Converts a string to a URL-encoded string using libcurl.
+ * inputString : const char* pointer to the input (raw) string.
+ * Returns: char* pointer to the encoded string (must be freed by the caller), or NULL on failure.
+ * NOTE: Input sanity checks are handled by curl_easy_escape.
+ *       The encoded string is duplicated with strdup, so the caller is responsible for freeing it.
+ *       The third argument to curl_easy_escape is set to 0, which tells libcurl to determine
+ *       the length of the input string automatically using strlen().
+ */
+char* urlEncodeString(const char* inputString)
+{
+    if (!inputString) {
+        COMMONUTILITIES_ERROR("Input string is NULL in Function %s\n", __FUNCTION__);
+        return NULL;
+    }
+    char* encodedString = NULL;
+    CURL *curl = curl_easy_init();
+    if (curl) 
+    {
+        char *output = curl_easy_escape(curl, inputString, 0);
+        if (output) {
+            encodedString = strdup(output);
+            curl_free(output);
+        } else {
+            COMMONUTILITIES_ERROR("curl_easy_escape failed in Function %s\n", __FUNCTION__);
+        }
+        curl_easy_cleanup(curl);
+    }
+    else
+    {
+        COMMONUTILITIES_ERROR("Error in curl_easy_init in Function %s\n", __FUNCTION__);
+    }
+    return encodedString;
+}
+
+
 #ifdef GTEST_ENABLE
 long (*getperformRequest(void)) (CURL *, CURLcode *) {
 	return &performRequest;

--- a/dwnlutils/urlHelper.h
+++ b/dwnlutils/urlHelper.h
@@ -136,6 +136,8 @@ int allocDowndLoadDataMem( DownloadData *pDwnData, int szDataSize );
 bool checkDeviceInternetConnection(long);
 size_t writeFunction(void *contents, size_t size, size_t nmemb, void *userp);
 void closeFile(DownloadData *data, struct curlprogress *prog, FILE *fp);
+char* urlEncodeString(const char* inputString); // This will internally use curl_easy_escape
+
 #if CURL_DEBUG
 CURLcode setCurlDebugOpt(CURL *curl, DbgData_t *debug);
 #endif

--- a/unit-test/dwnlutils/urlHelper_gtest.cpp
+++ b/unit-test/dwnlutils/urlHelper_gtest.cpp
@@ -915,6 +915,46 @@ TEST_F(urlHelperTestFixture, writeFunction_valid_Inputs)
     EXPECT_EQ(writeFunction(NULL, a, b, &test), a*b );
 }
 
+/*26.Test that passing NULL returns NULL */
+TEST(UrlEncodeStringTest, NullInputReturnsNull) {
+    char* result = urlEncodeString(nullptr);
+    EXPECT_EQ(result, nullptr);
+}
+
+/*27.Test that encoding an empty string returns an empty string */
+TEST(UrlEncodeStringTest, EmptyString) {
+    char* result = urlEncodeString("");
+    ASSERT_NE(result, nullptr);
+    EXPECT_STREQ(result, "");
+    free(result);
+}
+
+/*28.Test that a simple alphanumeric string is unchanged */
+TEST(UrlEncodeStringTest, SimpleString) {
+    char* result = urlEncodeString("abc123");
+    ASSERT_NE(result, nullptr);
+    EXPECT_STREQ(result, "abc123");
+    free(result);
+}
+
+/*29.Test that spaces are encoded as %20 */
+TEST(UrlEncodeStringTest, SpaceEncoding) {
+    char* result = urlEncodeString("hello world");
+    ASSERT_NE(result, nullptr);
+    EXPECT_STREQ(result, "hello%20world");
+    free(result);
+}
+
+/*30.Test encoding of a string with all ASCII special characters */
+TEST(UrlEncodeStringTest, AllAscii) {
+    // Using a string with various ASCII characters that need encoding
+    const char* input = "!*'();:@&=+$,/?#[]";
+    char* result = urlEncodeString(input);
+    ASSERT_NE(result, nullptr);
+    EXPECT_STREQ(result, "%21%2A%27%28%29%3B%3A%40%26%3D%2B%24%2C%2F%3F%23%5B%5D");
+    free(result);
+}
+
 GTEST_API_ int main(int argc, char *argv[]){
     char testresults_fullfilepath[GTEST_REPORT_FILEPATH_SIZE];
     char buffer[GTEST_REPORT_FILEPATH_SIZE];


### PR DESCRIPTION
Reason for change: providing support for URL encoding
Test Procedure: L1 test for url-encoding should be success
Risks: Low