### PR TITLE
RDKB-61159 [AUTO-SKY][Sprint]RFC is not working

### DIFF
--- a/utils/common_device_api.c
+++ b/utils/common_device_api.c
@@ -124,6 +124,11 @@ size_t GetPartnerId( char *pPartnerId, size_t szBufSize )
             }
             fclose( fp );
         }
+        else if( (fp = fopen( PARTNERID_INFO_FILE, "r" )) != NULL )
+        {
+            fgets( pPartnerId, szBufSize, fp );
+            fclose( fp );
+        }			
         else
         {
             snprintf( pPartnerId, szBufSize, "comcast" );

--- a/utils/common_device_api.c
+++ b/utils/common_device_api.c
@@ -18,6 +18,9 @@
 
 #include "common_device_api.h"
 #include "rdkv_cdl_log_wrapper.h"
+
+#define PARTNERID_INFO_FILE "/tmp/partnerId.out"
+
 /* function stripinvalidchar - truncates a string when a space or control
     character is encountered.
 

--- a/utils/common_device_api.h
+++ b/utils/common_device_api.h
@@ -38,7 +38,6 @@
 #ifndef GTEST_ENABLE
 #define BOOTSTRAP_FILE          "/opt/secure/RFC/bootstrap.ini"
 #define PARTNER_ID_FILE         "/opt/www/authService/partnerId3.dat"
-#define PARTNERID_INFO_FILE     "/tmp/partnerId.out"
 #define DEVICE_PROPERTIES_FILE  "/etc/device.properties"
 #define VERSION_FILE            "/version.txt"
 #define ESTB_MAC_FILE           "/tmp/.estb_mac"

--- a/utils/common_device_api.h
+++ b/utils/common_device_api.h
@@ -38,6 +38,7 @@
 #ifndef GTEST_ENABLE
 #define BOOTSTRAP_FILE          "/opt/secure/RFC/bootstrap.ini"
 #define PARTNER_ID_FILE         "/opt/www/authService/partnerId3.dat"
+#define PARTNERID_INFO_FILE     "/tmp/partnerId.out"
 #define DEVICE_PROPERTIES_FILE  "/etc/device.properties"
 #define VERSION_FILE            "/version.txt"
 #define ESTB_MAC_FILE           "/tmp/.estb_mac"


### PR DESCRIPTION
Update the utility function to use /tmp/partnerID.out file to retrieve the partner info in RDKB devices.